### PR TITLE
Removing return statement after panic statement

### DIFF
--- a/xml/node.go
+++ b/xml/node.go
@@ -802,7 +802,6 @@ func (xmlNode *XmlNode) serialize(format SerializationOption, encoding, outputBu
 	ret := int(C.xmlSaveNode(nodePtr, encodingPtr, C.int(format)))
 	if ret < 0 {
 		panic("output error in xml node serialization: " + strconv.Itoa(ret))
-		return nil, 0
 	}
 	b, o := wbuffer.Buffer, wbuffer.Offset
 	wbuffer = nil


### PR DESCRIPTION
When trying to run `go vet ./...` for the latest gokogiri release, the following error is returned:

```
➜  gokogiri git:(removeReturn) go vet ./...
xml/node.go:805: unreachable code
exit status 1
```

This PR removes the `return` statement that is after the `panic()` in xml/node.go.  Running `go vet./...` after this change works just fine:

```
➜  gokogiri git:(removeReturn) ✗ go vet ./...
➜  gokogiri git:(removeReturn) ✗
```
