### PR TITLE
include stdlib.h in xpath/expression.go

### DIFF
--- a/xpath/expression.go
+++ b/xpath/expression.go
@@ -1,6 +1,7 @@
 package xpath
 
 /*
+#include <stdlib.h>
 #include <libxml/xpath.h>
 #include <libxml/xpathInternals.h>
 #include <string.h>


### PR DESCRIPTION
Hello,
Thank you for maintaining gokogiri.
gokogiri is included in code that I want to cross compile.
Cross compilation of xpath/expression.go fails with the error "could not determine kind of name for C.free".
Including stdlib.h in xpath/expression.go solves the problem.
I am not aware of an other way to solve the problem.
Thank you for your help with this matter.